### PR TITLE
Update object-path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4441,8 +4441,8 @@
       "dev": true
     },
     "object-path": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
+      "version": ">=0.11.5",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.5.tgz",
       "integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU=",
       "dev": true
     },
@@ -6283,7 +6283,7 @@
       "dev": true,
       "requires": {
         "chalk": "^1.1.1",
-        "object-path": "^0.9.0"
+        "object-path": ">=0.11.5"
       },
       "dependencies": {
         "ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/usds/abc-prototype#readme",
   "devDependencies": {
     "autoprefixer": "^9.8.4",
-    "browser-sync": "^2.26.12",
+    "browser-sync": "^2.26.13",
     "gulp": "^4.0.2",
     "gulp-notify": "^3.2.0",
     "gulp-postcss": "^8.0.0",


### PR DESCRIPTION
Fixes [Dependabot alert](https://github.com/usds/html-prototype/network/alert/package-lock.json/object-path/open) for object-path vulnerability.